### PR TITLE
feat(libx11-dev) to include Xlib.h

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN \
         libarchive-tools \
         gdb \
         mingw-w64 \
+        libx11-dev \
         ${crossbuild_pkgs}\
  && apt -y autoremove \
  && apt-get clean \


### PR DESCRIPTION
This PR intends to include Xlib headers to help compile go programs depending on Xlib


Expected result: Compilation passes without any issue when Xlib headers are required

Current result:
` fatal error: X11/Xlib.h: No such file or directory`